### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/yields/convertagbyieldsfishlock14.py
+++ b/yields/convertagbyieldsfishlock14.py
@@ -46,7 +46,7 @@ with open('data/fishlock-z001-20140503/lifetimes.dat','r') as flifetimes:
     for line in flifetimes:
         linesplit = line.split()
         for m in range(len(initMass)):
-            if "%1.2f" % initMass[m] == linesplit[0]:
+            if "{0:1.2f}".format(initMass[m]) == linesplit[0]:
                 lifetime[m] = float(linesplit[1])
 
 for m in range(len(agbYieldFiles)):
@@ -71,10 +71,10 @@ with open('yields.txt', 'w') as fileout:
 
     for i in range(len(agbModelNames)):
         fileout.write((agbModelNames[i]).ljust(25))
-        fileout.write(("%6.2f" % float(agbModelNames[i][1:5].rstrip('z'))).rjust(14)) # mass
-        fileout.write(("%6.2e" % 0.001).rjust(14)) # metallicity
-        fileout.write(("%6.3f" % (initMass[i]  - ejectaMass[i])).rjust(14))   # remnant mass
-        fileout.write(("%.6e" % lifetime[i]).rjust(14))
+        fileout.write(("{0:6.2f}".format(float(agbModelNames[i][1:5].rstrip('z')))).rjust(14)) # mass
+        fileout.write(("{0:6.2e}".format(0.001)).rjust(14)) # metallicity
+        fileout.write(("{0:6.3f}".format((initMass[i]  - ejectaMass[i]))).rjust(14))   # remnant mass
+        fileout.write(("{0:.6e}".format(lifetime[i])).rjust(14))
         fileout.write("\n")
 
     fileout.write("\n" + "#species".ljust(8))
@@ -95,6 +95,6 @@ with open('yields.txt', 'w') as fileout:
             fileout.write("relative".rjust(10))
 
         for i in range(len(yields)):
-            fileout.write(("%14.6e" % yields[i][species]).rjust(14))
+            fileout.write(("{0:14.6e}".format(yields[i][species])).rjust(14))
 
         fileout.write("\n")

--- a/yields/convertyieldsfruity0003.py
+++ b/yields/convertyieldsfruity0003.py
@@ -80,10 +80,10 @@ with open('yields.txt', 'w') as fileout:
 
     for i in range(len(modelNames)):
         fileout.write((chr(ord('A') + i) + ':' + modelNames[i]).ljust(25)[:25])
-        fileout.write(("%6.2f" % initMass[i]).rjust(14))   # mass
-        fileout.write(("%6.2e" % metallicity[i]).rjust(14))   # metallicity
-        fileout.write(("%6.3f" % (initMass[i]  - ejectaMass[i])).rjust(14))   # remnant mass
-        fileout.write(("%.6e" % lifetime[i]).rjust(14))
+        fileout.write(("{0:6.2f}".format(initMass[i])).rjust(14))   # mass
+        fileout.write(("{0:6.2e}".format(metallicity[i])).rjust(14))   # metallicity
+        fileout.write(("{0:6.3f}".format((initMass[i]  - ejectaMass[i]))).rjust(14))   # remnant mass
+        fileout.write(("{0:.6e}".format(lifetime[i])).rjust(14))
         fileout.write("\n")
 
     fileout.write("\n" + "#species".ljust(8))
@@ -108,6 +108,6 @@ with open('yields.txt', 'w') as fileout:
                 yieldout = yields[i][species]
             else:
                 yieldout = 0.0
-            fileout.write(("%14.6e" % yieldout).rjust(14))
+            fileout.write(("{0:14.6e}".format(yieldout)).rjust(14))
 
         fileout.write("\n")

--- a/yields/convertyieldsshingles15.py
+++ b/yields/convertyieldsshingles15.py
@@ -104,10 +104,10 @@ with open('yields.txt', 'w') as fileout:
 
     for i in range(len(modelNames)):
         fileout.write((chr(ord('A') + i) + ':' + modelNames[i]).ljust(25)[:25])
-        fileout.write(("%6.2f" % initMass[i]).rjust(14))   # mass
-        fileout.write(("%6.2e" % metallicity[i]).rjust(14))   # metallicity
-        fileout.write(("%6.3f" % (initMass[i]  - ejectaMass[i])).rjust(14))   # remnant mass
-        fileout.write(("%.6e" % lifetime[i]).rjust(14))
+        fileout.write(("{0:6.2f}".format(initMass[i])).rjust(14))   # mass
+        fileout.write(("{0:6.2e}".format(metallicity[i])).rjust(14))   # metallicity
+        fileout.write(("{0:6.3f}".format((initMass[i]  - ejectaMass[i]))).rjust(14))   # remnant mass
+        fileout.write(("{0:.6e}".format(lifetime[i])).rjust(14))
         fileout.write("\n")
 
     fileout.write("\n" + "#species".ljust(8))
@@ -137,6 +137,6 @@ with open('yields.txt', 'w') as fileout:
                 yieldout = 0.0
                 if i == k06startindex:
                     print("Warning: '" + species + "' undefined for Kobayashi+2006 models")
-            fileout.write(("%14.6e" % yieldout).rjust(14))
+            fileout.write(("{0:14.6e}".format(yieldout)).rjust(14))
 
         fileout.write("\n")


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:lukeshingles:evelchemevol?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:lukeshingles:evelchemevol?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
